### PR TITLE
Extend `llvm::yaml::SequenceTraits` for batch insertion

### DIFF
--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -1123,16 +1123,42 @@ yamlize(IO &io, T &Val, bool, EmptyContext &Ctx) {
   char missing_yaml_trait_for_type[sizeof(MissingTrait<T>)];
 }
 
+template<typename T>
+class DefaultInserter {
+private:
+  IO &io;
+  T &Seq;
+
+public:
+  DefaultInserter(IO &io, T &Seq) : io(io), Seq(Seq) {}
+
+  auto &preflightElement(unsigned i) {
+    return SequenceTraits<T>::element(io, Seq, i);
+  }
+
+  void postflightElement(unsigned i) {};
+};
+
+template<typename T>
+auto getInserter(const T &) -> typename SequenceTraits<T>::Inserter {
+  return std::declval<typename SequenceTraits<T>::Inserter>();
+}
+
+template<typename T>
+DefaultInserter<T> getInserter(...) { return DefaultInserter<T>{}; }
+
 template <typename T, typename Context>
 typename std::enable_if<has_SequenceTraits<T>::value, void>::type
 yamlize(IO &io, T &Seq, bool, Context &Ctx) {
+  decltype(getInserter<T>(std::declval<T>())) I(io, Seq);
   if ( has_FlowTraits< SequenceTraits<T>>::value ) {
     unsigned incnt = io.beginFlowSequence();
     unsigned count = io.outputting() ? SequenceTraits<T>::size(io, Seq) : incnt;
     for(unsigned i=0; i < count; ++i) {
       void *SaveInfo;
       if ( io.preflightFlowElement(i, SaveInfo) ) {
-        yamlize(io, SequenceTraits<T>::element(io, Seq, i), true, Ctx);
+        yamlize(io, I.preflightElement(i), true, Ctx);
+        I.postflightElement(i);
         io.postflightFlowElement(SaveInfo);
       }
     }
@@ -1144,7 +1170,8 @@ yamlize(IO &io, T &Seq, bool, Context &Ctx) {
     for(unsigned i=0; i < count; ++i) {
       void *SaveInfo;
       if ( io.preflightElement(i, SaveInfo) ) {
-        yamlize(io, SequenceTraits<T>::element(io, Seq, i), true, Ctx);
+        yamlize(io, I.preflightElement(i), true, Ctx);
+        I.postflightElement(i);
         io.postflightElement(SaveInfo);
       }
     }


### PR DESCRIPTION
We need this change in order to do [this](https://github.com/revng/revng/blob/feature/model/include/revng/ADT/KeyedObjectContainer.h#L56).
Comments?