### PR TITLE
Properly quote ambiguous boolean-like scalars

### DIFF
--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -641,7 +641,12 @@ inline bool isNull(StringRef S) {
 inline bool isBool(StringRef S) {
   // FIXME: using parseBool is causing multiple tests to fail.
   return S.equals("true") || S.equals("True") || S.equals("TRUE") ||
-         S.equals("false") || S.equals("False") || S.equals("FALSE");
+         S.equals("yes") || S.equals("Yes") || S.equals ("YES") ||
+         S.equals("on") || S.equals("On") || S.equals ("ON") ||
+         S.equals("false") || S.equals("False") || S.equals("FALSE") ||
+         S.equals("no") || S.equals("No") || S.equals("NO") ||
+         S.equals("off") || S.equals("Off") || S.equals("OFF") ||
+         S.equals("y") || S.equals("Y") || S.equals("n") || S.equals("N");
 }
 
 // 5.1. Character Set

--- a/llvm/test/CodeGen/MIR/X86/variable-sized-stack-objects.mir
+++ b/llvm/test/CodeGen/MIR/X86/variable-sized-stack-objects.mir
@@ -30,11 +30,11 @@ frameInfo:
 # CHECK-NEXT: - { id: 1, name: '', type: default, offset: -32, size: 8, alignment: 8,
 # CHECK-NEXT:  stack-id: default, callee-saved-register: '', callee-saved-restored: true,
 # CHECK-NEXT: debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-# CHECK-NEXT: - { id: 2, name: y, type: variable-sized, offset: -32, alignment: 1,
+# CHECK-NEXT: - { id: 2, name: 'y', type: variable-sized, offset: -32, alignment: 1,
 stack:
   - { id: 0, offset: -20, size: 4, alignment: 4 }
   - { id: 1, offset: -32, size: 8, alignment: 8 }
-  - { id: 2, name: y, type: variable-sized, offset: -32, alignment: 1 }
+  - { id: 2, name: 'y', type: variable-sized, offset: -32, alignment: 1 }
 body: |
   bb.0.entry:
     MOV32mr $rsp, 1, _, -4, _, $edi

--- a/llvm/test/DebugInfo/COFF/global-type-hashes.ll
+++ b/llvm/test/DebugInfo/COFF/global-type-hashes.ll
@@ -227,7 +227,7 @@ attributes #2 = { noinline nounwind optnone "correctly-rounded-divide-sqrt-fp-ma
 ; YAML:               Attrs:           3
 ; YAML:               Type:            116
 ; YAML:               FieldOffset:     4
-; YAML:               Name:            Y
+; YAML:               Name:            'Y'
 ; YAML:           - Kind:            LF_ONEMETHOD
 ; YAML:             OneMethod:
 ; YAML:               Type:            4103

--- a/llvm/test/ObjectYAML/MachO/DWARF-BigEndian.yaml
+++ b/llvm/test/ObjectYAML/MachO/DWARF-BigEndian.yaml
@@ -272,7 +272,7 @@ DWARF:
     - long long int
     - __absvdi2
     - a
-    - N
+    - 'N'
     - t
   debug_abbrev:
     - Table:
@@ -384,7 +384,7 @@ DWARF:
 #CHECK:     - long long int
 #CHECK:     - __absvdi2
 #CHECK:     - a
-#CHECK:     - N
+#CHECK:     - 'N'
 #CHECK:     - t
 #CHECK:   debug_abbrev:    
 #CHECK:     - Code:            0x1

--- a/llvm/test/ObjectYAML/MachO/DWARF-LittleEndian.yaml
+++ b/llvm/test/ObjectYAML/MachO/DWARF-LittleEndian.yaml
@@ -261,7 +261,7 @@ DWARF:
     - long long int
     - __absvdi2
     - a
-    - N
+    - 'N'
     - t
   debug_abbrev:
     - Table:
@@ -373,7 +373,7 @@ DWARF:
 #CHECK:     - long long int
 #CHECK:     - __absvdi2
 #CHECK:     - a
-#CHECK:     - N
+#CHECK:     - 'N'
 #CHECK:     - t
 #CHECK:   debug_abbrev:    
 #CHECK:     - Code:            0x1

--- a/llvm/test/YAMLParser/bool.test
+++ b/llvm/test/YAMLParser/bool.test
@@ -1,6 +1,24 @@
 # RUN: yaml-bench -canonical %s
 
-- yes
-- NO
+- true
 - True
+- TRUE
+- yes
+- Yes
+- YES
 - on
+- On
+- ON
+- false
+- False
+- FALSE
+- no
+- No
+- NO
+- off
+- Off
+- OFF
+- y
+- Y
+- n
+- N

--- a/llvm/test/tools/llvm-size/common.test
+++ b/llvm/test/tools/llvm-size/common.test
@@ -34,7 +34,7 @@ Sections:
   - Name: .text
     Type: SHT_PROGBITS
 Symbols:
-  - Name:  y
+  - Name:  'y'
     Type:  STT_OBJECT
     Size:  4
     Index: SHN_COMMON


### PR DESCRIPTION
This commit adds quoting to some ambiguous strings that if not quoted get interpreted as booleans by a spec-compliant parser.
For example, without this commit, LLVM would serialize an object like `{"propertyName": "y"}` as
```yaml
propertyName: y
```
which should be quoted instead.