### PR TITLE
Drop: assertion too strict for revng usecase

### DIFF
--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -243,13 +243,6 @@ Type *TypeMapTy::get(Type *Ty, SmallPtrSet<StructType *, 8> &Visited) {
   bool IsUniqued = !isa<StructType>(Ty) || cast<StructType>(Ty)->isLiteral();
 
   if (!IsUniqued) {
-#ifndef NDEBUG
-    for (auto &Pair : MappedTypes) {
-      assert(!(Pair.first != Ty && Pair.second == Ty) &&
-             "mapping to a source type");
-    }
-#endif
-
     if (!Visited.insert(cast<StructType>(Ty)).second) {
       StructType *DTy = StructType::create(Ty->getContext());
       return *Entry = DTy;


### PR DESCRIPTION
this is related to a larger set of merger requests affecting revng and 
revng-c too, but It does not require changes to work correctly, and it 
can be merged alone too. 

IRmover asserts that a two types into two modules can be pointer wise
identical only if they are mapped to each other. This assumption arise
from the idea that modules are usually created indipendently from each
other.

We cannot make that assumption because the pipeline clones and merges
back modules from the same origin.