### PR TITLE
Make some LLVM LoopPass API public

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/LoopUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopUtils.h
@@ -420,6 +420,9 @@ bool cannotBeMaxInLoop(const SCEV *S, const Loop *L, ScalarEvolution &SE,
 bool cannotBeMinInLoop(const SCEV *S, const Loop *L, ScalarEvolution &SE,
                        bool Signed);
 
+/// TODO: This will be dropped when we are rebased onto newer version of LLVM.
+bool isValidRewrite(ScalarEvolution *SE, Value *FromVal, Value *ToVal);
+
 enum ReplaceExitVal { NeverRepl, OnlyCheapRepl, NoHardUse, AlwaysRepl };
 
 /// If the final value of any expressions that are recurrent in the loop can

--- a/llvm/include/llvm/Transforms/Utils/SimplifyIndVar.h
+++ b/llvm/include/llvm/Transforms/Utils/SimplifyIndVar.h
@@ -59,6 +59,10 @@ bool simplifyLoopIVs(Loop *L, ScalarEvolution *SE, DominatorTree *DT,
                      LoopInfo *LI, const TargetTransformInfo *TTI,
                      SmallVectorImpl<WeakTrackingVH> &Dead);
 
+/// We make it public so it can be used in our LLVM out-of-tree Passes.
+Instruction *getInsertPointForUses(Instruction *User, Value *Def,
+                                   DominatorTree *DT, LoopInfo *LI);
+
 /// Collect information about induction variables that are used by sign/zero
 /// extend operations. This information is recorded by CollectExtend and provides
 /// the input to WidenIV.

--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -1149,7 +1149,7 @@ bool llvm::cannotBeMaxInLoop(const SCEV *S, const Loop *L, ScalarEvolution &SE,
 // original value. SCEV guarantees that it produces the same value, but the way
 // it is produced may be illegal IR.  Ideally, this function will only be
 // called for verification.
-static bool isValidRewrite(ScalarEvolution *SE, Value *FromVal, Value *ToVal) {
+bool llvm::isValidRewrite(ScalarEvolution *SE, Value *FromVal, Value *ToVal) {
   // If an SCEV expression subsumed multiple pointers, its expansion could
   // reassociate the GEP changing the base pointer. This is illegal because the
   // final address produced by a GEP chain must be inbounds relative to its

--- a/llvm/lib/Transforms/Utils/SimplifyIndVar.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyIndVar.cpp
@@ -1107,8 +1107,8 @@ private:
 /// common dominator for the incoming blocks. A nullptr can be returned if no
 /// viable location is found: it may happen if User is a PHI and Def only comes
 /// to this PHI from unreachable blocks.
-static Instruction *getInsertPointForUses(Instruction *User, Value *Def,
-                                          DominatorTree *DT, LoopInfo *LI) {
+Instruction *llvm::getInsertPointForUses(Instruction *User, Value *Def,
+                                         DominatorTree *DT, LoopInfo *LI) {
   PHINode *PHI = dyn_cast<PHINode>(User);
   if (!PHI)
     return User;


### PR DESCRIPTION
This method will be removed in newer versions of LLVM, and we will resolve that by removing it from our codebase.