### PR TITLE
Make ExitOnError constructor external

### DIFF
--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -1306,9 +1306,7 @@ Error createFileError(const Twine &F, ErrorSuccess) = delete;
 class ExitOnError {
 public:
   /// Create an error on exit helper.
-  ExitOnError(std::string Banner = "", int DefaultErrorExitCode = 1)
-      : Banner(std::move(Banner)),
-        GetExitCode([=](const Error &) { return DefaultErrorExitCode; }) {}
+  ExitOnError(std::string Banner = "", int DefaultErrorExitCode = 1);
 
   /// Set the banner string for any errors caught by operator().
   void setBanner(std::string Banner) { this->Banner = std::move(Banner); }

--- a/llvm/lib/Support/Error.cpp
+++ b/llvm/lib/Support/Error.cpp
@@ -172,3 +172,7 @@ LLVMErrorTypeId LLVMGetStringErrorTypeId() {
 LLVMErrorRef LLVMCreateStringError(const char *ErrMsg) {
   return wrap(make_error<StringError>(ErrMsg, inconvertibleErrorCode()));
 }
+
+ExitOnError::ExitOnError(std::string Banner, int DefaultErrorExitCode)
+      : Banner(std::move(Banner)),
+        GetExitCode([=](const Error &) { return DefaultErrorExitCode; }) {}


### PR DESCRIPTION
The lambda in the constructor is a significant source of build time overhead in downstream projects.