### PR TITLE
Progress reporting

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1468,6 +1468,10 @@ template <typename ContainerTy> auto make_second_range(ContainerTy &&c) {
       });
 }
 
+template <typename R> auto make_address_range(R &&Range) {
+  return map_range(Range, [](auto &Element) { return &Element; });
+}
+
 //===----------------------------------------------------------------------===//
 //     Extra additions to <utility>
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/IR/LegacyPassManagers.h
+++ b/llvm/include/llvm/IR/LegacyPassManagers.h
@@ -498,6 +498,8 @@ public:
 
   StringRef getPassName() const override { return "Function Pass Manager"; }
 
+  bool isSingleTask() const override { return true; }
+
   FunctionPass *getContainedPass(unsigned N) {
     assert ( N < PassVector.size() && "Pass number out of range!");
     FunctionPass *FP = static_cast<FunctionPass *>(PassVector[N]);

--- a/llvm/include/llvm/Pass.h
+++ b/llvm/include/llvm/Pass.h
@@ -106,6 +106,8 @@ public:
   /// Registration templates, but can be overloaded directly.
   virtual StringRef getPassName() const;
 
+  virtual bool isSingleTask() const;
+
   /// getPassID - Return the PassID number that corresponds to this pass.
   AnalysisID getPassID() const {
     return PassID;

--- a/llvm/include/llvm/Support/Progress.h
+++ b/llvm/include/llvm/Support/Progress.h
@@ -1,0 +1,255 @@
+//===-- Progress - Generic infrastructure to report progress ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_PROGRESS_H
+#define LLVM_SUPPORT_PROGRESS_H
+
+extern "C" {
+#include <unistd.h>
+}
+
+#include <algorithm>
+#include <chrono>
+#include <optional>
+#include <set>
+#include <vector>
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/Threading.h"
+
+namespace llvm {
+
+class Progress;
+class TaskStack;
+
+/// Track advancement of a task
+///
+/// A task can have a name and optionally a set of maximum steps.
+class Task {
+protected:
+  TaskStack &Stack;
+  int64_t StepIndex = -1;
+  std::optional<int64_t> TotalSteps;
+
+private:
+  std::string TaskName;
+  std::string StepName;
+  bool SubtaskCreated = false;
+  bool Completed = false;
+  bool CurrentStepHasSingleSubtask = false;
+
+public:
+  Task(std::optional<int64_t> TotalSteps, const llvm::Twine &TaskName = "");
+
+  Task(const Task &) = delete;
+  Task(Task &&) = delete;
+
+  ~Task();
+
+public:
+  llvm::StringRef name() const { return TaskName; }
+  llvm::StringRef stepName() const { return StepName; }
+  /// \return -1 if no step (i.e., call to advance) has been initiated,
+  ///         the index of the last initiated step otherwise.
+  int64_t stepIndex() const { return StepIndex; }
+  std::optional<int64_t> totalSteps() const { return TotalSteps; }
+  bool subtaskCreated() const { return SubtaskCreated; }
+  bool currentStepHasSingleSubtask() const {
+    return CurrentStepHasSingleSubtask;
+  }
+  bool completed() const { return Completed; }
+  size_t index() const;
+
+  TaskStack &stack() { return Stack; }
+  const TaskStack &stack() const { return Stack; }
+
+public:
+  /// \param NewStepName the name of the new step starting after this advance
+  ///        invocation.
+  /// \param SingleSubtask whether we can expect 0 or 1 subtask being created
+  ///        during this step. If true, will assert in case multiple subtasks
+  ///        are create during this step.
+  void advance(const llvm::Twine &NewStepName = "", bool SingleSubtask = false);
+
+  void setSubtaskCreated();
+
+  void complete();
+};
+
+/// Represents the set of tasks started but not completed in an execution thread
+class TaskStack {
+private:
+  Progress &Parent;
+  unsigned SuspendRequests = 0;
+
+public:
+  llvm::SmallVector<Task *, 4> Tasks;
+
+public:
+  TaskStack(Progress &Parent) : Parent(Parent) {}
+
+  TaskStack(TaskStack &&) = delete;
+  TaskStack(const TaskStack &) = delete;
+  TaskStack &operator=(const TaskStack &) = delete;
+  TaskStack &operator=(TaskStack &&) = delete;
+
+public:
+  void registerTask(Task *T);
+  void unregisterTask(Task *T);
+  void advanceTask(Task *T, llvm::StringRef PreviousStepName);
+
+public:
+  bool isSuspended() const { return SuspendRequests > 0; }
+  void resumeTracking() {
+    assert(isSuspended());
+    --SuspendRequests;
+  }
+
+  void suspendTracking() { ++SuspendRequests; }
+};
+
+/// Class to monitor progress of a Progress instance
+class ProgressListener {
+public:
+  virtual ~ProgressListener() = default;
+
+  /// Invoked to notify the creation of a new task
+  ///
+  /// \note \p T will always be the last task of its stack.
+  ///
+  /// \note This method could be called by multiple threads in parallel.
+  virtual void handleNewTask(const Task *T) = 0;
+
+  /// Invoked to notify the completion of a task
+  ///
+  /// \note \p T will always be the last task of its stack.
+  ///
+  /// \note This method could be called by multiple threads in parallel.
+  virtual void handleTaskCompleted(const Task *T) = 0;
+
+  /// Invoked to notify of the advancement of a certain task to a new step
+  ///
+  /// \note \p T will always be the last task of its stack.
+  ///
+  /// \note This method could be called by multiple threads in parallel.
+  virtual void handleTaskAdvancement(const Task *T,
+                                     llvm::StringRef PreviousStepName) = 0;
+};
+
+/// Class to monitor progress of task staks over multiple threads
+class Progress {
+private:
+  struct RegistryEntry {
+    bool AllThreads = false;
+    std::unique_ptr<ProgressListener> Listener;
+  };
+
+private:
+  uint64_t MainThreadID;
+  llvm::SmallVector<RegistryEntry, 2> Registry;
+
+public:
+  Progress();
+
+public:
+  /// \note call this method from the main thread only.
+  template <typename T, typename... Types>
+  void registerListener(Types &&...Args) {
+    assert(isMainThread());
+    Registry.push_back({T::AllThreads, std::make_unique<T>(Args...)});
+  }
+
+public:
+  bool isMainThread() const;
+
+public:
+  void handleNewTask(const Task *T);
+  void handleTaskCompleted(const Task *T);
+  void handleTaskAdvancement(const Task *T, llvm::StringRef PreviousStepName);
+};
+
+/// The default instance of Progress each Task will use
+extern llvm::ManagedStatic<Progress> ProgressReport;
+
+/// Similar to Task, but gets a list of objects at construction times that
+/// represent elements the task iterates on.
+/// Each invocation of advance accepts a similar object: if the passed object is
+/// not in the list of expected objects, the monitor of progress will be
+/// suspended until the next step.
+template <typename ValueType,
+          typename Set = std::conditional_t<std::is_pointer_v<ValueType>,
+                                            llvm::SmallPtrSet<ValueType, 16>,
+                                            std::set<ValueType>>>
+class TaskOnSet : public Task {
+private:
+  Set Predicted;
+  bool Suspended = false;
+
+public:
+  template <typename R>
+  TaskOnSet(R &&Elements, const llvm::Twine &TaskName = "")
+      : Task({}, TaskName) {
+    unsigned Count = 0;
+    for (const auto &Element : Elements) {
+      Predicted.insert(Element);
+      ++Count;
+    }
+
+    TotalSteps = Predicted.size();
+
+    assert(TotalSteps == Count);
+  }
+
+  ~TaskOnSet() {
+    if (Suspended)
+      Stack.resumeTracking();
+  }
+
+public:
+  void advance(const ValueType &Element, const llvm::Twine &NewStepName = "",
+               bool SingleSubtask = false) {
+
+    if (Predicted.count(Element) != 0) {
+      if (Suspended) {
+        Stack.resumeTracking();
+        Suspended = false;
+      }
+
+      // This is an expected element, proceed
+      Task::advance(NewStepName, SingleSubtask);
+
+    } else {
+      if (not Suspended) {
+        // Ignore all unexpected elements
+        Stack.suspendTracking();
+        Suspended = true;
+      }
+    }
+  }
+};
+
+template <typename R>
+auto make_task_on_set(R &&Elements, const llvm::Twine &TaskName = "") {
+  return TaskOnSet<std::decay_t<decltype(*std::declval<R>().begin())>>(
+      Elements, TaskName);
+}
+
+template <typename R>
+auto make_task_on_set(TaskStack &Stack, R &&Elements,
+                      const llvm::Twine &TaskName = "") {
+  return TaskOnSet<std::decay_t<decltype(*std::declval<R>().begin())>>(
+      Stack, Elements, TaskName);
+}
+
+} // namespace llvm
+
+#endif

--- a/llvm/lib/IR/LegacyPassManager.cpp
+++ b/llvm/lib/IR/LegacyPassManager.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/IR/LLVMContext.h"
@@ -24,6 +25,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Progress.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
@@ -358,7 +360,9 @@ bool FunctionPassManagerImpl::run(Function &F) {
   bool Changed = false;
 
   initializeAllAnalysisInfo();
+  Task T(getNumContainedManagers(), "Run function pass managers");
   for (unsigned Index = 0; Index < getNumContainedManagers(); ++Index) {
+    T.advance();
     Changed |= getContainedManager(Index)->runOnFunction(F);
     F.getContext().yield();
   }
@@ -422,6 +426,8 @@ public:
                                            Function &F) override;
 
   StringRef getPassName() const override { return "Module Pass Manager"; }
+
+  bool isSingleTask() const override { return true; }
 
   PMDataManager *getAsPMDataManager() override { return this; }
   Pass *getAsPass() override { return this; }
@@ -531,7 +537,9 @@ bool PassManagerImpl::run(Module &M) {
     Changed |= ImPass->doInitialization(M);
 
   initializeAllAnalysisInfo();
+  Task T(getNumContainedManagers(), "Run module pass managers");
   for (unsigned Index = 0; Index < getNumContainedManagers(); ++Index) {
+    T.advance();
     Changed |= getContainedManager(Index)->runOnModule(M);
     M.getContext().yield();
   }
@@ -1410,8 +1418,10 @@ bool FPPassManager::runOnFunction(Function &F) {
 
   llvm::TimeTraceScope FunctionScope("OptFunction", F.getName());
 
+  Task T(getNumContainedPasses(), "Run function passes");
   for (unsigned Index = 0; Index < getNumContainedPasses(); ++Index) {
     FunctionPass *FP = getContainedPass(Index);
+    T.advance(FP->getPassName(), FP->isSingleTask());
     bool LocalChanged = false;
 
     llvm::TimeTraceScope PassScope("RunPass", FP->getPassName());
@@ -1472,8 +1482,11 @@ bool FPPassManager::runOnFunction(Function &F) {
 bool FPPassManager::runOnModule(Module &M) {
   bool Changed = false;
 
-  for (Function &F : M)
+  auto T = make_task_on_set(make_address_range(M), "Run function pass manager");
+  for (Function &F : M) {
+    T.advance(&F, F.getName());
     Changed |= runOnFunction(F);
+  }
 
   return Changed;
 }
@@ -1525,8 +1538,10 @@ MPPassManager::runOnModule(Module &M) {
   if (EmitICRemark)
     InstrCount = initSizeRemarkInfo(M, FunctionToInstrCount);
 
+  Task T(getNumContainedPasses(), "Run module passes");
   for (unsigned Index = 0; Index < getNumContainedPasses(); ++Index) {
     ModulePass *MP = getContainedPass(Index);
+    T.advance(MP->getPassName(), MP->isSingleTask());
     bool LocalChanged = false;
 
     dumpPassInfo(MP, EXECUTION_MSG, ON_MODULE_MSG, M.getModuleIdentifier());

--- a/llvm/lib/IR/Pass.cpp
+++ b/llvm/lib/IR/Pass.cpp
@@ -86,6 +86,10 @@ StringRef Pass::getPassName() const {
   return "Unnamed pass: implement Pass::getPassName()";
 }
 
+bool Pass::isSingleTask() const {
+  return false;
+}
+
 void Pass::preparePassManager(PMStack &) {
   // By default, don't do anything.
 }

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -198,6 +198,7 @@ add_llvm_component_library(LLVMSupport
   Parallel.cpp
   PluginLoader.cpp
   PrettyStackTrace.cpp
+  Progress.cpp
   RandomNumberGenerator.cpp
   Regex.cpp
   RISCVAttributes.cpp

--- a/llvm/lib/Support/Progress.cpp
+++ b/llvm/lib/Support/Progress.cpp
@@ -1,0 +1,116 @@
+//===-- Progress - Generic infrastructure to report progress ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the core logic for progress reporting.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/Progress.h"
+
+using namespace llvm;
+
+ManagedStatic<Progress> llvm::ProgressReport;
+
+static thread_local TaskStack CurrentStack(*ProgressReport);
+
+Progress::Progress() : MainThreadID(get_threadid()) {}
+
+bool Progress::isMainThread() const { return MainThreadID == get_threadid(); }
+
+void Progress::handleNewTask(const Task *T) {
+  bool IsMainThread = isMainThread();
+  for (auto &[AllThreads, Listener] : Registry)
+    if (IsMainThread or AllThreads)
+      Listener->handleNewTask(T);
+}
+
+void Progress::handleTaskCompleted(const Task *T) {
+  bool IsMainThread = isMainThread();
+  for (auto &[AllThreads, Listener] : Registry)
+    if (IsMainThread or AllThreads)
+      Listener->handleTaskCompleted(T);
+}
+
+void Progress::handleTaskAdvancement(const Task *T,
+                                     StringRef PreviousStepName) {
+  bool IsMainThread = isMainThread();
+  for (auto &[AllThreads, Listener] : Registry)
+    if (IsMainThread or AllThreads)
+      Listener->handleTaskAdvancement(T, PreviousStepName);
+}
+
+Task::Task(std::optional<int64_t> TotalSteps, const Twine &TaskName)
+    : Stack(CurrentStack), TotalSteps(TotalSteps), TaskName(TaskName.str()) {
+  Stack.registerTask(this);
+}
+
+void Task::complete() {
+  if (not Completed) {
+    Completed = true;
+    Stack.unregisterTask(this);
+  }
+}
+
+Task::~Task() { complete(); }
+
+void Task::advance(const Twine &NewStepName, bool SingleSubtask) {
+  int64_t NewStepIndex = StepIndex + 1;
+  if (TotalSteps.has_value()) {
+    assert(NewStepIndex < *TotalSteps);
+  }
+  StepIndex = NewStepIndex;
+  std::string PreviousStepName = std::move(StepName);
+  StepName = NewStepName.str();
+  SubtaskCreated = false;
+  CurrentStepHasSingleSubtask = SingleSubtask;
+
+  Stack.advanceTask(this, PreviousStepName);
+}
+
+void Task::setSubtaskCreated() { SubtaskCreated = true; }
+
+size_t Task::index() const {
+  auto &Stack = stack();
+  auto Begin = Stack.Tasks.begin();
+  auto End = Stack.Tasks.end();
+  auto It = std::find(Begin, End, this);
+  assert(It != End);
+  return It - Begin;
+}
+
+void TaskStack::registerTask(Task *T) {
+  if (isSuspended())
+    return;
+
+  if (Tasks.size() > 0) {
+    if (T->currentStepHasSingleSubtask()) {
+      assert(not Tasks.back()->subtaskCreated());
+    }
+    Tasks.back()->setSubtaskCreated();
+  }
+
+  Tasks.push_back(T);
+
+  Parent.handleNewTask(T);
+}
+
+void TaskStack::unregisterTask(Task *T) {
+  if (isSuspended())
+    return;
+
+  assert(Tasks.back() == T);
+  Parent.handleTaskCompleted(T);
+  Tasks.pop_back();
+}
+
+void TaskStack::advanceTask(Task *T, StringRef PreviousStepName) {
+  if (isSuspended())
+    return;
+
+  Parent.handleTaskAdvancement(T, PreviousStepName);
+}

--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -127,8 +127,6 @@ uint64_t llvm::get_threadid() {
 #elif defined(__ANDROID__)
   return uint64_t(gettid());
 #elif defined(__linux__)
-  return uint64_t(syscall(SYS_gettid));
-#else
   return uint64_t(pthread_self());
 #endif
 }

--- a/llvm/lib/Transforms/IPO/SCCP.cpp
+++ b/llvm/lib/Transforms/IPO/SCCP.cpp
@@ -114,11 +114,15 @@ static bool runIPSCCP(
     function_ref<AnalysisResultsForFn(Function &)> getAnalysis,
     bool IsFuncSpecEnabled) {
   SCCPSolver Solver(DL, GetTLI, M.getContext());
+  auto T = make_task_on_set(make_address_range(M), "LLVM SCC Passes");
+
   FunctionSpecializer Specializer(Solver, M, FAM, GetTLI, GetTTI, GetAC);
 
   // Loop over all functions, marking arguments to those with their addresses
   // taken or that are external as overdefined.
   for (Function &F : M) {
+    T.advance(&F, F.getName());
+
     if (F.isDeclaration())
       continue;
 

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -4609,11 +4609,15 @@ static bool combineInstructionsOverFunction(
       RemoveRedundantDbgInstrs(&BB);
   }
 
+  Task T({}, "InstCombine");
+
   // Iterate while there is work to do.
   unsigned Iteration = 0;
   while (true) {
     ++NumWorklistIterations;
     ++Iteration;
+
+    T.advance();
 
     if (Iteration > InfiniteLoopDetectionThreshold) {
       report_fatal_error(

--- a/llvm/lib/Transforms/Scalar/SCCP.cpp
+++ b/llvm/lib/Transforms/Scalar/SCCP.cpp
@@ -186,4 +186,3 @@ INITIALIZE_PASS_END(SCCPLegacyPass, "sccp",
 
 // createSCCPPass - This is the public interface to this file.
 FunctionPass *llvm::createSCCPPass() { return new SCCPLegacyPass(); }
-

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -22,7 +22,6 @@ endif()
 
 # Must go below project(..)
 include(GNUInstallDirs)
-set(CMAKE_CXX_STANDARD 17)
 
 if(MLIR_STANDALONE_BUILD)
   find_package(LLVM CONFIG REQUIRED)


### PR DESCRIPTION
This PR introduces in LLVM the necessary infrastructure to report and monitor progress.
It also instruments certain common parts of the mid end as appropriate to adopt progress reporting.

Multiple example of `ProgressListener` implementations can be found in the [revng/revng sister PR](https://github.com/revng/revng/pull/258/files#diff-a12699d0069ad462f959f92fca3cb95aa3a502deffbdb014192c4a8ae4e2fa37).