### PR TITLE
Explicit `DomTreeBuilder` method instantiation and MLIR dot serialization improvements

### DIFF
--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -279,7 +279,9 @@ def ViewOpGraph : Pass<"view-op-graph"> {
     Option<"printResultTypes", "print-result-types", "bool",
             /*default=*/"true", "Print result types of operations">,
     Option<"printRegionControlFlowEdges", "print-region-control-flow-edges",
-           "bool", /*default=*/"false", "Print region control flow edges">
+           "bool", /*default=*/"false", "Print region control flow edges">,
+    Option<"onlyEntryAndExitOperations", "only-entry-exit-ops",
+           "bool", /*default=*/"false", "Print only entry and exit operations">
   ];
   let constructor = "mlir::createPrintOpGraphPass()";
 }

--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -277,7 +277,9 @@ def ViewOpGraph : Pass<"view-op-graph"> {
     Option<"printDataFlowEdges", "print-data-flow-edges", "bool",
            /*default=*/"true", "Print data flow edges">,
     Option<"printResultTypes", "print-result-types", "bool",
-            /*default=*/"true", "Print result types of operations">
+            /*default=*/"true", "Print result types of operations">,
+    Option<"printRegionControlFlowEdges", "print-region-control-flow-edges",
+           "bool", /*default=*/"false", "Print region control flow edges">
   ];
   let constructor = "mlir::createPrintOpGraphPass()";
 }

--- a/mlir/lib/IR/Dominance.cpp
+++ b/mlir/lib/IR/Dominance.cpp
@@ -24,6 +24,13 @@ template class llvm::DominatorTreeOnView<Block, /*IsPostDom=*/false, llvm::DTIde
 template class llvm::DominatorTreeOnView<Block, /*IsPostDom=*/true, llvm::DTIdentityView>;
 template class llvm::DomTreeNodeOnView<Block, llvm::DTIdentityView>;
 
+// Explicit instantiation for the `llvm::DomTreeBuilder::DeleteEdge` method,
+template void llvm::DomTreeBuilder::DeleteEdge<Block, false, llvm::DTIdentityView>(
+  DomTreeOnView<Block, DTIdentityView> &DT, Block *From, Block *To);
+
+template void llvm::DomTreeBuilder::DeleteEdge<Block, true, llvm::DTIdentityView>(
+  PostDomTreeOnView<Block, DTIdentityView> &DT, Block *From, Block *To);
+
 //===----------------------------------------------------------------------===//
 // DominanceInfoBase
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/GraphWriter.h"
+#include "llvm/Support/raw_ostream.h"
 #include <utility>
 #include <optional>
 
@@ -28,6 +29,7 @@ using namespace mlir;
 
 static const StringRef kLineStyleControlFlow = "dashed";
 static const StringRef kLineStyleDataFlow = "solid";
+static const StringRef kLineStyleRegionControlFlow = "bold";
 static const StringRef kShapeNode = "ellipse";
 static const StringRef kShapeNone = "plain";
 
@@ -82,6 +84,10 @@ public:
 /// Note: See https://www.graphviz.org/doc/info/lang.html for more information
 /// about the Graphviz DOT language.
 class PrintOpPass : public impl::ViewOpGraphBase<PrintOpPass> {
+private:
+  llvm::DenseMap<mlir::Block *, Node> blockFirstNodeMap;
+  llvm::DenseMap<mlir::Block *, Node> blockLastNodeMap;
+
 public:
   PrintOpPass(raw_ostream &os) : os(os) {}
   PrintOpPass(const PrintOpPass &o) : PrintOpPass(o.os.getOStream()) {}
@@ -250,6 +256,11 @@ private:
   /// Process a block. Emit a cluster and one node per block argument and
   /// operation inside the cluster.
   void processBlock(Block &block) {
+
+    // Prepare the name for the block node
+    std::string nodeName;
+    llvm::raw_string_ostream blockNameStr(nodeName);
+    block.printAsOperand(blockNameStr);
     emitClusterStmt([&]() {
       for (BlockArgument &blockArg : block.getArguments())
         valueToNode[blockArg] = emitNodeStmt(getLabel(blockArg));
@@ -261,9 +272,18 @@ private:
         if (printControlFlowEdges && prevNode)
           emitEdgeStmt(*prevNode, nextNode, /*label=*/"",
                        kLineStyleControlFlow);
+
+        // If we are at first iteration, save the first operand node for the
+        // incoming edges.
+        if (not prevNode) {
+          blockFirstNodeMap[&block] = nextNode;
+        }
         prevNode = nextNode;
       }
-    });
+
+      // Save the last operation for the outgoing edges.
+      blockLastNodeMap[&block] = *prevNode;
+    }, nodeName);
   }
 
   /// Process an operation. If the operation has regions, emit a cluster.
@@ -301,6 +321,22 @@ private:
   void processRegion(Region &region) {
     for (Block &block : region.getBlocks())
       processBlock(block);
+
+    // Print control flow edges between blocks if the option is activated.
+    if (printRegionControlFlowEdges) {
+      for (Block &block : region.getBlocks()) {
+        unsigned numSuccessors = block.getNumSuccessors();
+        for (unsigned i = 0; i < numSuccessors; i++) {
+          Block *successor = block.getSuccessor(i);
+          assert(blockLastNodeMap.count(&block) == 1);
+          Node blockNode = blockLastNodeMap[&block];
+          assert(blockFirstNodeMap.count(successor) == 1);
+          Node successorNode = blockFirstNodeMap[successor];
+          emitEdgeStmt(blockNode, successorNode,
+                       /*label=*/numSuccessors == 1 ? "" : std::to_string(i), kLineStyleRegionControlFlow);
+        }
+      }
+    }
   }
 
   /// Truncate long strings.


### PR DESCRIPTION
- Explicit instantiation of the `DeleteEdge` method for the `DomTreeBuilder` class accepting `mlir::Block` as first template parameter.
- Improve the serialization of MLIR modules by printing the CFG connecting blocks.