### PR TITLE
SetVector: implement `takeSet` method

### DIFF
--- a/llvm/include/llvm/ADT/SetVector.h
+++ b/llvm/include/llvm/ADT/SetVector.h
@@ -68,6 +68,12 @@ public:
     return std::move(vector_);
   }
 
+  /// Clear the SetVector and return the underlying set.
+  Set takeSet() {
+    vector_.clear();
+    return std::move(set_);
+  }
+
   /// Determine if the SetVector is empty or not.
   bool empty() const {
     return vector_.empty();


### PR DESCRIPTION
- Implement the `takeSet` method, specular to the `takeVector` one, in order to extract the inner `llvm::DenseSet` from the `llvm::SetVector` container.
- This method, concurrently clears the associated inner `std::vector`.
