### PR TITLE
Add option to emit hex literals in LLVM IR

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -88,6 +88,14 @@
 
 using namespace llvm;
 
+static cl::opt<uint64_t>
+EmitHexConstantLiteralsFrom("emit-hex-constant-literals-from",
+                             cl::desc("Emit constant literals greater than or"
+                                      " equal to a certain unsigned value in"
+                                      " hexadecimal in LLVM IR."),
+                             cl::init(std::numeric_limits<uint64_t>::max()));
+
+
 // Make virtual table appear in this compilation unit.
 AssemblyAnnotationWriter::~AssemblyAnnotationWriter() = default;
 
@@ -1353,7 +1361,16 @@ static void WriteConstantInternal(raw_ostream &Out, const Constant *CV,
       Out << (CI->getZExtValue() ? "true" : "false");
       return;
     }
-    Out << CI->getValue();
+
+    if (EmitHexConstantLiteralsFrom != std::numeric_limits<uint64_t>::max()
+        && CI->getValue().uge(EmitHexConstantLiteralsFrom)) {
+      std::string Value = llvm::toString(CI->getValue(), 16, false, false);
+      llvm::transform(Value, Value.begin(), tolower);
+      Out << "u0x" << Value;
+    } else {
+      Out << CI->getValue();
+    }
+
     return;
   }
 

--- a/llvm/lib/Transforms/Utils/CodeExtractor.cpp
+++ b/llvm/lib/Transforms/Utils/CodeExtractor.cpp
@@ -231,8 +231,8 @@ buildExtractionBlockSet(ArrayRef<BasicBlock *> BBs, DominatorTree *DT,
       if (!Result.count(PBB)) {
         LLVM_DEBUG(dbgs() << "No blocks in this region may have entries from "
                              "outside the region except for the first block!\n"
-                          << "Problematic source BB: " << BB->getName() << "\n"
-                          << "Problematic destination BB: " << PBB->getName()
+                          << "Problematic source BB: " << PBB->getName() << "\n"
+                          << "Problematic destination BB: " << BB->getName()
                           << "\n");
         return {};
       }


### PR DESCRIPTION
The idea is to have this be the default in revng.

The constants are emitted as u0x1000. This a feature already supported in parsing, this branch only introduces an option to emit them by default.

```llvm
define dso_local i32 @main() #0 {
entry:
  %retval = alloca i32, align 4
  store i32 u0x0, ptr %retval, align 4
  ret i32 u0x2a
}
```